### PR TITLE
feat: add protected routing ml-11

### DIFF
--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -11,27 +11,29 @@ import { AppRoute } from "~/libs/enums/enums.js";
 import { store } from "~/libs/modules/store/store.js";
 import { Auth } from "~/pages/auth/auth.jsx";
 
+import { ProtectedRoute } from "./libs/components/router-provider/protected-route.js";
+
 createRoot(document.querySelector("#root") as HTMLElement).render(
 	<StrictMode>
 		<StoreProvider store={store.instance}>
 			<RouterProvider
 				routes={[
 					{
+						element: <Auth />,
+						path: AppRoute.SIGN_IN,
+					},
+					{
+						element: <Auth />,
+						path: AppRoute.SIGN_UP,
+					},
+					{
 						children: [
 							{
-								element: "Root",
+								element: <App />,
 								path: AppRoute.ROOT,
 							},
-							{
-								element: <Auth />,
-								path: AppRoute.SIGN_IN,
-							},
-							{
-								element: <Auth />,
-								path: AppRoute.SIGN_UP,
-							},
 						],
-						element: <App />,
+						element: <ProtectedRoute />,
 						path: AppRoute.ROOT,
 					},
 				]}

--- a/apps/frontend/src/libs/components/router-provider/protected-route.tsx
+++ b/apps/frontend/src/libs/components/router-provider/protected-route.tsx
@@ -1,0 +1,24 @@
+import { FC } from "react";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+
+import { AppRoute } from "~/libs/enums/enums.js";
+import { useAppSelector } from "~/libs/hooks/hooks.js";
+
+const ProtectedRoute: FC = () => {
+	const isAuthenticated = useAppSelector((state) => state.auth.isAuthenticated);
+	const location = useLocation();
+
+	if (!isAuthenticated) {
+		return (
+			<Navigate
+				replace
+				state={{ from: location.pathname }}
+				to={AppRoute.SIGN_IN}
+			/>
+		);
+	}
+
+	return <Outlet />;
+};
+
+export { ProtectedRoute };

--- a/apps/frontend/src/libs/components/router-provider/protected-route.tsx
+++ b/apps/frontend/src/libs/components/router-provider/protected-route.tsx
@@ -5,7 +5,7 @@ import { AppRoute } from "~/libs/enums/enums.js";
 import { useAppSelector } from "~/libs/hooks/hooks.js";
 
 const ProtectedRoute: FC = () => {
-	const isAuthenticated = useAppSelector((state) => state.auth.isAuthenticated);
+	const isAuthenticated = useAppSelector((state) => state.auth.user !== null);
 	const location = useLocation();
 
 	if (!isAuthenticated) {

--- a/apps/frontend/src/modules/auth/slices/auth.slice.ts
+++ b/apps/frontend/src/modules/auth/slices/auth.slice.ts
@@ -7,10 +7,14 @@ import { signUp } from "./actions.js";
 
 type State = {
 	dataStatus: ValueOf<typeof DataStatus>;
+	isAuthenticated: boolean;
+	token: null | string;
 };
 
 const initialState: State = {
 	dataStatus: DataStatus.IDLE,
+	isAuthenticated: false,
+	token: null,
 };
 
 const { actions, name, reducer } = createSlice({

--- a/apps/frontend/src/modules/auth/slices/auth.slice.ts
+++ b/apps/frontend/src/modules/auth/slices/auth.slice.ts
@@ -1,18 +1,15 @@
+import { UserResponseDto } from "@meetlytic/shared";
 import { createSlice } from "@reduxjs/toolkit";
 
 import { DataStatus } from "~/libs/enums/enums.js";
 import { type ValueOf } from "~/libs/types/types.js";
-import { type UserSignUpResponseDto as User } from "~/modules/users/users.js";
 
 import { signUp } from "./actions.js";
-
-//TODO import User or what kind of object will be there to store user data
-// import { User } from "";
 
 type State = {
 	dataStatus: ValueOf<typeof DataStatus>;
 	token: null | string;
-	user: null | User;
+	user: null | UserResponseDto;
 };
 
 const initialState: State = {

--- a/apps/frontend/src/modules/auth/slices/auth.slice.ts
+++ b/apps/frontend/src/modules/auth/slices/auth.slice.ts
@@ -2,19 +2,23 @@ import { createSlice } from "@reduxjs/toolkit";
 
 import { DataStatus } from "~/libs/enums/enums.js";
 import { type ValueOf } from "~/libs/types/types.js";
+import { type UserSignUpResponseDto as User } from "~/modules/users/users.js";
 
 import { signUp } from "./actions.js";
 
+//TODO import User or what kind of object will be there to store user data
+// import { User } from "";
+
 type State = {
 	dataStatus: ValueOf<typeof DataStatus>;
-	isAuthenticated: boolean;
 	token: null | string;
+	user: null | User;
 };
 
 const initialState: State = {
 	dataStatus: DataStatus.IDLE,
-	isAuthenticated: false,
 	token: null,
+	user: null,
 };
 
 const { actions, name, reducer } = createSlice({


### PR DESCRIPTION
- [x] Create ProtectedRoute wrapper component
- [x] Redirect not signed in users from protected screens to Sign In page

Please note: using this branch activates protected routing, which means you will not be able to access any pages except for login and registration until the relevant authorization issues are activated.