### PR TITLE
fix: allow access to Swagger UI ml-72

### DIFF
--- a/apps/backend/src/libs/constants/white-routes.constant.ts
+++ b/apps/backend/src/libs/constants/white-routes.constant.ts
@@ -6,7 +6,7 @@ const WHITE_ROUTES: WhiteRoute[] = [
 	{ method: "POST", path: `${APIPath.AUTH}${AuthApiPath.SIGN_UP}` },
 	{ method: "POST", path: `${APIPath.AUTH}${AuthApiPath.SIGN_IN}` },
 
-	{ method: "GET", path: "/documentation*" },
+	{ method: "GET", path: "/documentation" },
 ];
 
 export { WHITE_ROUTES };

--- a/apps/backend/src/libs/constants/white-routes.constant.ts
+++ b/apps/backend/src/libs/constants/white-routes.constant.ts
@@ -6,19 +6,7 @@ const WHITE_ROUTES: WhiteRoute[] = [
 	{ method: "POST", path: `${APIPath.AUTH}${AuthApiPath.SIGN_UP}` },
 	{ method: "POST", path: `${APIPath.AUTH}${AuthApiPath.SIGN_IN}` },
 
-	{ method: "GET", path: "/documentation" },
-	{ method: "GET", path: "/documentation/static/swagger-ui.css" },
-	{ method: "GET", path: "/documentation/static/index.css" },
-	{ method: "GET", path: "/documentation/static/swagger-ui-bundle.js" },
-	{
-		method: "GET",
-		path: "/documentation/static/swagger-ui-standalone-preset.js",
-	},
-	{
-		method: "GET",
-		path: "/documentation/static/swagger-initializer.js",
-	},
-	{ method: "GET", path: "/documentation/json" },
+	{ method: "GET", path: "/documentation*" },
 ];
 
 export { WHITE_ROUTES };

--- a/apps/backend/src/libs/constants/white-routes.constant.ts
+++ b/apps/backend/src/libs/constants/white-routes.constant.ts
@@ -5,6 +5,20 @@ import { type WhiteRoute } from "./libs/types/types.js";
 const WHITE_ROUTES: WhiteRoute[] = [
 	{ method: "POST", path: `${APIPath.AUTH}${AuthApiPath.SIGN_UP}` },
 	{ method: "POST", path: `${APIPath.AUTH}${AuthApiPath.SIGN_IN}` },
+
+	{ method: "GET", path: "/documentation" },
+	{ method: "GET", path: "/documentation/static/swagger-ui.css" },
+	{ method: "GET", path: "/documentation/static/index.css" },
+	{ method: "GET", path: "/documentation/static/swagger-ui-bundle.js" },
+	{
+		method: "GET",
+		path: "/documentation/static/swagger-ui-standalone-preset.js",
+	},
+	{
+		method: "GET",
+		path: "/documentation/static/swagger-initializer.js",
+	},
+	{ method: "GET", path: "/documentation/json" },
 ];
 
 export { WHITE_ROUTES };

--- a/apps/backend/src/libs/modules/server-application/base-server-application-api.ts
+++ b/apps/backend/src/libs/modules/server-application/base-server-application-api.ts
@@ -51,7 +51,7 @@ class BaseServerApplicationApi implements ServerApplicationApi {
 					version: `${this.version}.0.0`,
 				},
 				openapi: "3.0.0",
-				servers: [{ url: "/api/v1" }],
+				servers: [{ url: `/${this.version}` }],
 			},
 		});
 	}

--- a/apps/backend/src/libs/modules/server-application/base-server-application.ts
+++ b/apps/backend/src/libs/modules/server-application/base-server-application.ts
@@ -209,7 +209,7 @@ class BaseServerApplication implements ServerApplication {
 				});
 
 				await this.app.register(swaggerUi, {
-					routePrefix: `${api.version}/documentation`,
+					routePrefix: `/api/${api.version}/documentation`,
 				});
 			}),
 		);

--- a/apps/backend/src/libs/plugins/authorization/authorization.plugin.ts
+++ b/apps/backend/src/libs/plugins/authorization/authorization.plugin.ts
@@ -29,6 +29,10 @@ const authorizationPlugin: FastifyPluginCallback<Options> = fp(
 		fastify.addHook(FastifyHook.PRE_HANDLER, async (request) => {
 			const { method, url } = request;
 
+			if (/^\/api\/v\d+\/documentation/.test(url)) {
+				return;
+			}
+
 			const apiPrefixRegex = /^\/api\/v\d+(?:\/|$)/;
 
 			const endpointToCompare = url.replace(apiPrefixRegex, "/");

--- a/apps/backend/src/libs/plugins/authorization/authorization.plugin.ts
+++ b/apps/backend/src/libs/plugins/authorization/authorization.plugin.ts
@@ -29,6 +29,10 @@ const authorizationPlugin: FastifyPluginCallback<Options> = fp(
 		fastify.addHook(FastifyHook.PRE_HANDLER, async (request) => {
 			const { method, url } = request;
 
+			if (url.startsWith("/api/v1/documentation")) {
+				return;
+			}
+
 			const apiPrefixRegex = /^\/api\/v\d+(?:\/|$)/;
 
 			const endpointToCompare = url.replace(apiPrefixRegex, "/");

--- a/apps/backend/src/libs/plugins/authorization/authorization.plugin.ts
+++ b/apps/backend/src/libs/plugins/authorization/authorization.plugin.ts
@@ -29,7 +29,7 @@ const authorizationPlugin: FastifyPluginCallback<Options> = fp(
 		fastify.addHook(FastifyHook.PRE_HANDLER, async (request) => {
 			const { method, url } = request;
 
-			if (url.startsWith("/api/v1/documentation")) {
+			if (/^\/api\/v\d+\/documentation/.test(url)) {
 				return;
 			}
 

--- a/apps/backend/src/libs/plugins/authorization/authorization.plugin.ts
+++ b/apps/backend/src/libs/plugins/authorization/authorization.plugin.ts
@@ -29,10 +29,6 @@ const authorizationPlugin: FastifyPluginCallback<Options> = fp(
 		fastify.addHook(FastifyHook.PRE_HANDLER, async (request) => {
 			const { method, url } = request;
 
-			if (/^\/api\/v\d+\/documentation/.test(url)) {
-				return;
-			}
-
 			const apiPrefixRegex = /^\/api\/v\d+(?:\/|$)/;
 
 			const endpointToCompare = url.replace(apiPrefixRegex, "/");


### PR DESCRIPTION
Now Swagger UI can be accessed at `http://localhost:3000/api/v1/documentation` without authentication.