### PR TITLE
feat: add custom template for issues on github ml-99999

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: 🪲 Bug Report
+description: Report a bug
+title: "fix:"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to help everyone identify and fix the bug
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your issue
+      placeholder: When I click here this happens
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to page X
+        2. Click here
+        3. Look there
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What was the actual result?
+      placeholder: This happened
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What was the expected result?
+      placeholder: I expected this to happen
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Put here any screenshots or videos (optional)
+  - type: dropdown
+    id: OS
+    attributes:
+      label: "What OS are you seeing the problem on?"
+      multiple: true
+      options:
+        - "Windows"
+        - "MacOS"
+        - "Android"
+        - "Other (mention in the description)"
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: "What browsers are you seeing the problem on?"
+      multiple: true
+      options:
+        - "Chrome"
+        - "Safari"
+        - "Edge"
+        - "Firefox"
+        - "Opera"
+        - "Other (mention in the description)"
+    validations:
+      required: false
+  - type: dropdown
+    id: Severity
+    attributes:
+      label: "Severity"
+      options:
+        - "Blocker (S1)"
+        - "Critical (S2)"
+        - "Major (S3)"
+        - "Minor (S4)"
+        - "Trivial (S5)"
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting this issue!


### PR DESCRIPTION
<img width="986" height="2112" alt="image" src="https://github.com/user-attachments/assets/e7920601-7ae2-409c-8936-61e868f7f814" />
