### PR TITLE
fix: yaml semantic error in meetings.controller.ts ml-86

### DIFF
--- a/apps/backend/src/libs/modules/server-application/base-server-application.ts
+++ b/apps/backend/src/libs/modules/server-application/base-server-application.ts
@@ -140,8 +140,20 @@ class BaseServerApplication implements ServerApplication {
 
 		const schema: Record<string, unknown> = {};
 
-		if (validation?.body && !["DELETE", "GET", "HEAD"].includes(method)) {
+		if (validation?.body) {
 			schema["body"] = validation.body;
+		}
+
+		if (validation?.params) {
+			schema["params"] = validation.params;
+		}
+
+		if (validation?.querystring) {
+			schema["querystring"] = validation.querystring;
+		}
+
+		if (validation?.headers) {
+			schema["headers"] = validation.headers;
 		}
 
 		this.app.route({

--- a/apps/backend/src/libs/modules/server-application/base-server-application.ts
+++ b/apps/backend/src/libs/modules/server-application/base-server-application.ts
@@ -138,12 +138,16 @@ class BaseServerApplication implements ServerApplication {
 	public addRoute(parameters: ServerApplicationRouteParameters): void {
 		const { handler, method, path, validation } = parameters;
 
+		const schema: Record<string, unknown> = {};
+
+		if (validation?.body && !["DELETE", "GET", "HEAD"].includes(method)) {
+			schema["body"] = validation.body;
+		}
+
 		this.app.route({
 			handler,
 			method,
-			schema: {
-				body: validation?.body,
-			},
+			schema,
 			url: path,
 		});
 		this.logger.info(`Route: ${method} ${path} is registered`);

--- a/apps/backend/src/libs/modules/server-application/libs/types/server-application-route-parameters.type.ts
+++ b/apps/backend/src/libs/modules/server-application/libs/types/server-application-route-parameters.type.ts
@@ -17,6 +17,9 @@ type ServerApplicationRouteParameters = {
 	preHandlers?: preHandlerHookHandler | preHandlerHookHandler[] | undefined;
 	validation?: {
 		body?: ValidationSchema;
+		headers?: ValidationSchema;
+		params?: ValidationSchema;
+		querystring?: ValidationSchema;
 	};
 };
 

--- a/apps/backend/src/modules/meetings/meetings.controller.ts
+++ b/apps/backend/src/modules/meetings/meetings.controller.ts
@@ -32,23 +32,24 @@ import { type MeetingService } from "./meetings.service.js";
  *           type: number
  *         host:
  *           type: string
- * 			 enum:
- * 			   - zoom
+ *           enum:
+ *             - zoom
  *         instanceId:
  *           type: string
  *           nullable: true
  *         ownerId:
  *           type: number
- * 		   status:
- * 			 type: string
- * 			 enum:
- * 			   - started
- * 			   - ended
+ *         status:
+ *           type: string
+ *           enum:
+ *             - started
+ *             - ended
  *       required:
  *         - id
  *         - host
  *         - instanceId
  *         - ownerId
+ *         - status
  *     MeetingCreateRequest:
  *       type: object
  *       required:
@@ -56,8 +57,8 @@ import { type MeetingService } from "./meetings.service.js";
  *       properties:
  *         host:
  *           type: string
- * 			 enum:
- * 			   - zoom
+ *           enum:
+ *             - zoom
  *         instanceId:
  *           type: string
  *           nullable: true
@@ -65,18 +66,17 @@ import { type MeetingService } from "./meetings.service.js";
  *       type: object
  *       required:
  *         - host
- * 		   - status
+ *         - status
  *       properties:
  *         host:
  *           type: string
- * 			 enum:
- * 			   - zoom
- * 		   status:
- * 			 type: string
- * 			 enum:
+ *           enum:
+ *             - zoom
+ *         status:
+ *           type: string
+ *           enum:
  *             - started
- * 			   - ended
-
+ *             - ended
  */
 class MeetingsController extends BaseController {
 	private meetingService: MeetingService;


### PR DESCRIPTION
Additionally, I fixed the Fastify warnings 'The body schema is missing' for routes with methods GET, DELETE, and HEAD that do not contain a body.