### PR TITLE
fix: bot unable to select the leave button ml-265

### DIFF
--- a/apps/bot/src/libs/enums/zoom-bot-message.enum.ts
+++ b/apps/bot/src/libs/enums/zoom-bot-message.enum.ts
@@ -13,6 +13,7 @@ const ZoomBotMessage = {
 	FOUND_PASSCODE: "Passcode extracted from link:",
 	JOINED_MEETING: "Joined Zoom meeting successfully",
 	JOINING_MEETING: "is joining the meeting...",
+	LEFT_MEETING: "Bot has left the meeting.",
 	NAVIGATION_TO_ZOOM: "Navigating to Zoom meeting:",
 	ONLY_ONE_PARTICIPANT_DETECTED: "Only 1 participant detected. Leaving...",
 	PAGE_NOT_INITIALIZED: "Page not initialized.",

--- a/apps/bot/src/libs/modules/zoom/base-zoom-bot.ts
+++ b/apps/bot/src/libs/modules/zoom/base-zoom-bot.ts
@@ -267,6 +267,7 @@ class BaseZoomBot {
 	private async leaveMeeting(): Promise<void> {
 		try {
 			await this.clickHelper(ZoomUILabel.LEAVE);
+			await this.clickHelper(ZoomUILabel.LEAVE);
 			await delay(Timeout.FIVE_SECONDS);
 			await this.clickHelper(ZoomUILabel.CONFIRM_LEAVE);
 		} catch (error) {

--- a/apps/bot/src/libs/modules/zoom/base-zoom-bot.ts
+++ b/apps/bot/src/libs/modules/zoom/base-zoom-bot.ts
@@ -265,11 +265,12 @@ class BaseZoomBot {
 		await this.clickHelper(ZoomUILabel.JOIN);
 	}
 	private async leaveMeeting(): Promise<void> {
+		await this.clickHelper(ZoomUILabel.LEAVE);
+		await this.clickHelper(ZoomUILabel.LEAVE);
+
 		try {
-			await this.clickHelper(ZoomUILabel.LEAVE);
-			await this.clickHelper(ZoomUILabel.LEAVE);
-			await delay(Timeout.FIVE_SECONDS);
 			await this.clickHelper(ZoomUILabel.CONFIRM_LEAVE);
+			this.logger.info(ZoomBotMessage.LEFT_MEETING);
 		} catch (error) {
 			this.logger.error(
 				`${ZoomBotMessage.FAILED_TO_LEAVE_MEETING} ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
# Zoom "Leave" Button Behavior
In Zoom, the footer **“Leave”** button behaves differently from normal buttons:
1. **First click:** Only focuses or activates the button in Zoom’s custom footer UI.
2. **Second click:** Actually triggers the leave action.
3. **Confirmation dialog:** After the second click, a confirmation dialog appears, which must be clicked to confirm leaving the meeting.

```ts
private async leaveMeeting(): Promise<void> {
	// Zoom footer requires double click to trigger the leave action
	await this.clickHelper(ZoomUILabel.LEAVE); // first click: focus
	await this.clickHelper(ZoomUILabel.LEAVE); // second click: trigger

	try {
		// Confirm leaving the meeting
		await this.clickHelper(ZoomUILabel.CONFIRM_LEAVE);
		this.logger.info(ZoomBotMessage.LEFT_MEETING);
	} catch (error) {
		this.logger.error(
			`${ZoomBotMessage.FAILED_TO_LEAVE_MEETING} ${error instanceof Error ? error.message : String(error)}`,
		);
	}
}

```