### PR TITLE
fix: time formatting on meeting card ml-284

### DIFF
--- a/apps/frontend/src/pages/meetings/meetings.tsx
+++ b/apps/frontend/src/pages/meetings/meetings.tsx
@@ -61,7 +61,7 @@ const Meetings: React.FC = () => {
 							<MeetingItem
 								date={formatDate(
 									new Date(meeting.createdAt),
-									"MMM D, YYYY, h:m A",
+									"MMM D, YYYY, h:mm A",
 								)}
 								id={meeting.id}
 								key={meeting.id}

--- a/packages/shared/src/libs/types/date-format.type.ts
+++ b/packages/shared/src/libs/types/date-format.type.ts
@@ -1,3 +1,3 @@
-type DateFormat = "D MMMM hA" | "mm:ss" | "MMM D, YYYY, h:m A";
+type DateFormat = "D MMMM hA" | "mm:ss" | "MMM D, YYYY, h:mm A";
 
 export { type DateFormat };


### PR DESCRIPTION
![card_time](https://github.com/user-attachments/assets/38d0b149-21db-47de-a8ee-c6f91410a974)
