### PR TITLE
feat: use consistent datetime format ml-308

### DIFF
--- a/apps/frontend/src/libs/components/meeting-pdf/meeting-pdf.tsx
+++ b/apps/frontend/src/libs/components/meeting-pdf/meeting-pdf.tsx
@@ -1,4 +1,5 @@
 import { Document, Page, Text, View } from "~/libs/components/components.js";
+import { DateTimeFormat } from "~/libs/enums/enums.js";
 import { formatDate } from "~/libs/helpers/helpers.js";
 import { type MeetingPdfProperties } from "~/libs/types/types.js";
 
@@ -17,7 +18,7 @@ const MeetingPdf = ({
 				<View style={styles.section}>
 					<Text style={styles.title}>Meeting #{id}</Text>
 					<Text style={styles.text}>
-						Date: {formatDate(new Date(createdAt), "D MMMM hA")}
+						Date: {formatDate(new Date(createdAt), DateTimeFormat.MEETING)}
 					</Text>
 				</View>
 				<View style={styles.section}>

--- a/apps/frontend/src/libs/components/player-track/player-track.tsx
+++ b/apps/frontend/src/libs/components/player-track/player-track.tsx
@@ -3,7 +3,7 @@ import {
 	PERCENT_MULTIPLIER,
 	START_TIME,
 } from "~/libs/constants/constants.js";
-import { AudioEvent, KeyboardKey } from "~/libs/enums/enums.js";
+import { AudioEvent, DateTimeFormat, KeyboardKey } from "~/libs/enums/enums.js";
 import { formatDate, getValidClassNames } from "~/libs/helpers/helpers.js";
 import {
 	useCallback,
@@ -148,8 +148,15 @@ const PlayerTrack: React.FC<Properties> = ({ audioUrl }: Properties) => {
 				<span className="visually-hidden">Set playback position</span>
 			</button>
 			<div className={styles["time"]}>
-				{formatDate(new Date(currentTime * MILLISECONDS_IN_SECOND), "mm:ss")} /{" "}
-				{formatDate(new Date(duration * MILLISECONDS_IN_SECOND), "mm:ss")}
+				{formatDate(
+					new Date(currentTime * MILLISECONDS_IN_SECOND),
+					DateTimeFormat.AUDIO_PLAYER,
+				)}{" "}
+				/{" "}
+				{formatDate(
+					new Date(duration * MILLISECONDS_IN_SECOND),
+					DateTimeFormat.AUDIO_PLAYER,
+				)}
 			</div>
 			{/* We will not have captions file for this */}
 			{/* eslint-disable-next-line jsx-a11y/media-has-caption */}

--- a/apps/frontend/src/libs/enums/enums.ts
+++ b/apps/frontend/src/libs/enums/enums.ts
@@ -28,6 +28,7 @@ export {
 	APIPath,
 	AppEnvironment,
 	ContentType,
+	DateTimeFormat,
 	HTTPMethod,
 	KeyboardKey,
 	MeetingErrorMessage,

--- a/apps/frontend/src/pages/meeting-details/meeting-details.tsx
+++ b/apps/frontend/src/pages/meeting-details/meeting-details.tsx
@@ -12,6 +12,7 @@ import {
 import {
 	AppRoute,
 	DataStatus,
+	DateTimeFormat,
 	MeetingErrorMessage,
 	MeetingStatus,
 	NotificationMessage,
@@ -135,7 +136,7 @@ const MeetingDetails: React.FC = () => {
 				<div className={styles["meeting-details__header"]}>
 					<h1 className={styles["meeting-details__title"]}>
 						Meeting #{meeting.id} |{" "}
-						{formatDate(new Date(meeting.createdAt), "D MMMM hA")}
+						{formatDate(new Date(meeting.createdAt), DateTimeFormat.MEETING)}
 					</h1>
 					<div className={styles["meeting-details__actions"]}>
 						{user && (

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export {
 	APIPath,
 	AppEnvironment,
 	ContentType,
+	DateTimeFormat,
 	ExceptionMessage,
 	Extension,
 	KeyboardKey,

--- a/packages/shared/src/libs/enums/datetime-format.enum.ts
+++ b/packages/shared/src/libs/enums/datetime-format.enum.ts
@@ -1,0 +1,6 @@
+const DateTimeFormat = {
+	AUDIO_PLAYER: "mm:ss",
+	MEETING: "MMM D, YYYY, h:mm A",
+} as const;
+
+export { DateTimeFormat };

--- a/packages/shared/src/libs/enums/enums.ts
+++ b/packages/shared/src/libs/enums/enums.ts
@@ -1,6 +1,7 @@
 export { APIPath } from "./api-path.enum.js";
 export { AppEnvironment } from "./app-environment.enum.js";
 export { ContentType } from "./content-type.enum.js";
+export { DateTimeFormat } from "./datetime-format.enum.js";
 export { ExceptionMessage } from "./exception-message.enum.js";
 export { Extension } from "./extension.enum.js";
 export { KeyboardKey } from "./keyboard-key.enum.js";

--- a/packages/shared/src/libs/types/date-format.type.ts
+++ b/packages/shared/src/libs/types/date-format.type.ts
@@ -1,3 +1,3 @@
-type DateFormat = "D MMMM hA" | "mm:ss" | "MMM D, YYYY, h:mm A";
+type DateFormat = "mm:ss" | "MMM D, YYYY, h:mm A";
 
 export { type DateFormat };


### PR DESCRIPTION
<img width="855" height="405" alt="image" src="https://github.com/user-attachments/assets/68d12a2c-fc85-4bbc-b03a-af7d1d14def1" />

<img width="855" height="405" alt="image" src="https://github.com/user-attachments/assets/a64beef6-1513-4b4b-a112-b4799766a16b" />

<img width="353" height="269" alt="image" src="https://github.com/user-attachments/assets/8afbc9f8-5310-483c-86b3-69ca99cb38cb" />
