### PR TITLE
fix: add swap file and optimize puppeteer launch options ml-305

### DIFF
--- a/apps/bot/setup-ec2.sh
+++ b/apps/bot/setup-ec2.sh
@@ -214,3 +214,18 @@ echo "[+] ZoomBot launched (PID $!). Logs at /home/ubuntu/bot.log"
 echo "[\\0_0/] Setup complete. Bot is running with xvfb-run + Chromium:headless."
 echo "[i] Script finished at $(date)"
 # ──────────────────────────────────────────────────────────────────────────────
+
+# --- Add swap file (4GB) ---
+echo "[+] Adding 4GB swap file..."
+SWAPFILE=/swapfile
+if [ ! -f $SWAPFILE ]; then
+		fallocate -l 4G $SWAPFILE
+		chmod 600 $SWAPFILE
+		mkswap $SWAPFILE
+		swapon $SWAPFILE
+		echo "$SWAPFILE none swap sw 0 0" | tee -a /etc/fstab
+		echo "[+] Swap file created and activated."
+else
+		echo "[✓] Swap file already exists."
+fi
+

--- a/apps/bot/src/libs/modules/config/base-config.module.ts
+++ b/apps/bot/src/libs/modules/config/base-config.module.ts
@@ -144,7 +144,12 @@ class BaseConfig implements Config {
 			"--disable-setuid-sandbox",
 			"--autoplay-policy=no-user-gesture-required",
 			"--use-fake-ui-for-media-stream",
-			"--headless=true",
+			"--disable-gpu",
+			"--disable-extensions",
+			"--disable-backgrounding-occluded-windows",
+			"--disable-renderer-backgrounding",
+			"--disable-dev-shm-usage",
+			"--headless=new",
 		];
 
 		return {


### PR DESCRIPTION
# PR: Add Swap File and Optimize Puppeteer Chromium Launch for ZoomBot

## Changes Introduced

### 1. Add 4GB Swap File
- Creates `/swapfile` if it doesn’t exist.  
- Sets proper permissions, activates it, and persists in `/etc/fstab`.  
- Reduces out-of-memory issues on low-memory EC2 instances (e.g., t3.micro).  

### 2. Optimize Puppeteer Launch Arguments
- Added Chrome flags to reduce CPU/memory usage:
  - `--disable-gpu`
  - `--disable-extensions`
  - `--disable-backgrounding-occluded-windows`
  - `--disable-renderer-backgrounding`
  - `--disable-dev-shm-usage`
- Switched to **new headless mode**: `--headless=new` for better audio recording and compatibility.

## Impact
- ZoomBot should now run more reliably on EC2, with less memory/CPU pressure.  
- Audio recording remains functional in headless Chromium.  
- Swap file prevents crashes due to insufficient RAM during high load.

## Notes
- Swap creation is idempotent; safe to run multiple times.  
- Works on Ubuntu-based EC2 instances.
