### PR TITLE
fix: uploaded avatars appear stretched or distorted ml-371

### DIFF
--- a/apps/frontend/src/libs/components/avatar/styles.module.css
+++ b/apps/frontend/src/libs/components/avatar/styles.module.css
@@ -1,10 +1,10 @@
 .avatar {
-	border: 2px solid var(--color-brand);
-	border-radius: 50%;
 	display: block;
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
+	border: 2px solid var(--color-brand);
+	border-radius: 50%;
 }
 
 .avatar-small {

--- a/apps/frontend/src/libs/components/avatar/styles.module.css
+++ b/apps/frontend/src/libs/components/avatar/styles.module.css
@@ -1,6 +1,10 @@
 .avatar {
 	border: 2px solid var(--color-brand);
 	border-radius: 50%;
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
 }
 
 .avatar-small {

--- a/apps/frontend/src/modules/users/slices/users.slice.ts
+++ b/apps/frontend/src/modules/users/slices/users.slice.ts
@@ -50,7 +50,7 @@ const { actions, name, reducer } = createSlice({
 			state.dataStatus = DataStatus.PENDING;
 		});
 		builder.addCase(updateProfile.fulfilled, (state, { payload }) => {
-			state.user = payload;
+			state.user = { ...state.user, ...payload };
 			state.dataStatus = DataStatus.FULFILLED;
 		});
 		builder.addCase(updateProfile.rejected, (state) => {


### PR DESCRIPTION
# Fix avatar display and profile update merge

## Changes

- **Avatar display:**  
  - Added `object-fit: cover` to `.avatar` to prevent stretching/distortion.
  - Ensures consistent display for all image sizes.

- **Profile update:**  
  - Merged `updateProfile.fulfilled` payload with existing user data:  
    ```ts
    state.user = { ...state.user, ...payload };
    ```
  - Preserves existing fields (e.g., avatar) when updating profile.

## Impact

- Avatars display correctly regardless of original image dimensions.  
- Profile updates no longer overwrite existing user data.
