### PR TITLE
fix: add focus to play button after seek ml-362

### DIFF
--- a/apps/frontend/src/libs/components/player-track/player-track.tsx
+++ b/apps/frontend/src/libs/components/player-track/player-track.tsx
@@ -18,6 +18,7 @@ type Properties = {
 const PlayerTrack: React.FC<Properties> = ({ audioUrl }: Properties) => {
 	const audioReference = useRef<HTMLAudioElement>(null);
 	const progressReference = useRef<HTMLButtonElement>(null);
+	const playButtonReference = useRef<HTMLButtonElement>(null);
 
 	const [isPlaying, setIsPlaying] = useState<boolean>(false);
 	const [currentTime, setCurrentTime] = useState<number>(START_TIME);
@@ -91,6 +92,7 @@ const PlayerTrack: React.FC<Properties> = ({ audioUrl }: Properties) => {
 
 				audioReference.current.currentTime = newTime;
 				setCurrentTime(newTime);
+				playButtonReference.current?.focus();
 			}
 		},
 		[duration],
@@ -122,7 +124,11 @@ const PlayerTrack: React.FC<Properties> = ({ audioUrl }: Properties) => {
 
 	return (
 		<div className={styles["root"]}>
-			<button className={styles["button"]} onClick={handleClick}>
+			<button
+				className={styles["button"]}
+				onClick={handleClick}
+				ref={playButtonReference}
+			>
 				<Icon className={styles["icon"]} name={isPlaying ? "play" : "pause"} />
 				<span className="visually-hidden">
 					{isPlaying ? "Pause audio" : "Play audio"}


### PR DESCRIPTION
### Fix: Restore keyboard playback control after seeking in PlayerTrack

**Issue:**  
In Firefox, when a user seeks using the progress bar and then presses `Space` or `Enter`, playback would restart from the beginning instead of resuming. This happens because the progress bar gains focus after the click, so keyboard events are triggered on the wrong element.

**Solution:**  
- Added a `ref` to the play button (`playButtonReference`).  
- After a user seeks on the progress bar, focus is programmatically returned to the play button.  
- Ensures that `Space`/`Enter` toggle playback correctly regardless of prior interactions with the progress bar.

**Changes:**  
- Updated the play button element:
```tsx
<button
  className={styles["button"]}
  onClick={handleClick}
  ref={playButtonReference}
>
  <Icon className={styles["icon"]} name={isPlaying ? "play" : "pause"} />
  <span className="visually-hidden">
    {isPlaying ? "Pause audio" : "Play audio"}
  </span>
</button>
