### PR TITLE
fix: export button briefly flashes generating pdf during transcript updates ml-382

### DIFF
--- a/apps/frontend/src/pages/meeting-details/meeting-details.tsx
+++ b/apps/frontend/src/pages/meeting-details/meeting-details.tsx
@@ -116,7 +116,11 @@ const MeetingDetails: React.FC = () => {
 		void shareMeetingPublicUrl(meeting.id);
 	}, [meeting]);
 
-	const { transcriptions } = useAppSelector((state) => state.transcription);
+	const transcriptions = useAppSelector((state) =>
+		meeting?.status === MeetingStatus.ENDED
+			? state.transcription.transcriptions.items
+			: [],
+	);
 
 	if (!id || dataStatus === DataStatus.REJECTED) {
 		return <Navigate replace to={AppRoute.NOT_FOUND} />;
@@ -134,7 +138,7 @@ const MeetingDetails: React.FC = () => {
 		);
 	}
 
-	const transcription = transcriptions.items
+	const transcription = transcriptions
 		.map((item) => `• ${item.chunkText}`)
 		.join("\n");
 
@@ -149,7 +153,7 @@ const MeetingDetails: React.FC = () => {
 	};
 
 	const isMeetingEnded = meeting.status === MeetingStatus.ENDED;
-	const hasTranscript = transcriptions.items.length > EMPTY_ARRAY_LENGTH;
+	const hasTranscript = transcriptions.length > EMPTY_ARRAY_LENGTH;
 	const hasSummary = Boolean(meeting.summary?.trim());
 	const hasActionItems = Boolean(meeting.actionItems?.trim());
 
@@ -190,18 +194,22 @@ const MeetingDetails: React.FC = () => {
 							/>
 						)}
 
-						<PDFDownloadLink
-							document={<MeetingPdf {...meetingPdfProperties} />}
-							fileName={pdfFileName}
-							key={isMeetingEnded ? "pdf-ready" : "pdf-pending"}
-						>
-							{({ loading }) => (
-								<Button
-									isDisabled={!canExport}
-									label={loading ? "Generating PDF..." : "Export"}
-								/>
-							)}
-						</PDFDownloadLink>
+						{isMeetingEnded ? (
+							<PDFDownloadLink
+								document={<MeetingPdf {...meetingPdfProperties} />}
+								fileName={pdfFileName}
+								key="pdf-ready"
+							>
+								{({ loading }) => (
+									<Button
+										isDisabled={!canExport}
+										label={loading ? "Generating PDF..." : "Export"}
+									/>
+								)}
+							</PDFDownloadLink>
+						) : (
+							<Button isDisabled label="Export" />
+						)}
 					</div>
 				</div>
 


### PR DESCRIPTION
## PR Summary

- Fix PDF export button: disabled during meeting, active after meeting ends.
- Prevent duplicate PDF generation and unnecessary re-renders.
